### PR TITLE
Add benchmarks for individual contact polytopes depending on DoFs and polytope dimensions.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,11 @@ target_link_libraries(DynamicPolytope
 
 add_subdirectory(tests)
 
+option(WITH_POLYTOPES_BENCHMARK "Build benchmark for mc_dynamic_polytope library" OFF)
+if(WITH_POLYTOPES_BENCHMARK)
+  add_subdirectory(benchmark)
+endif()
+
 #### Exporting targets and installing ####
 
 install(

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -1,0 +1,14 @@
+find_package(benchmark REQUIRED)
+
+# Configure Google Benchmark to skip its own tests and docs.
+set(BENCHMARK_ENABLE_GTEST_TESTS OFF CACHE BOOL "" FORCE)
+set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "" FORCE)
+set(BENCHMARK_ENABLE_INSTALL OFF CACHE BOOL "" FORCE)
+
+add_executable(polytope_bench bench.cpp)
+
+target_link_libraries(polytope_bench PRIVATE
+  benchmark::benchmark
+  benchmark::benchmark_main
+  DynamicPolytope
+)

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -1,9 +1,17 @@
-find_package(benchmark REQUIRED)
+include(FetchContent)
 
 # Configure Google Benchmark to skip its own tests and docs.
 set(BENCHMARK_ENABLE_GTEST_TESTS OFF CACHE BOOL "" FORCE)
 set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "" FORCE)
 set(BENCHMARK_ENABLE_INSTALL OFF CACHE BOOL "" FORCE)
+
+FetchContent_Declare(
+  googlebenchmark
+  GIT_REPOSITORY https://github.com/google/benchmark.git
+  GIT_TAG v1.9.5
+)
+
+FetchContent_MakeAvailable(googlebenchmark)
 
 add_executable(polytope_bench bench.cpp)
 

--- a/benchmark/bench.cpp
+++ b/benchmark/bench.cpp
@@ -8,6 +8,15 @@
 #include <benchmark/benchmark.h>
 #include <mc_dynamic_polytopes/DynamicPolytope.h>
 
+void addDummySurface(mc_rbdyn::Robot & robot, std::string surfaceName, std::string parentBodyName)
+{
+  // create a dummy square surface
+  std::vector<std::pair<double, double>> points = {{-0.1, -0.1}, {0.1, -0.1}, {0.1, 0.1}, {-0.1, 0.1}};
+  std::shared_ptr<mc_rbdyn::Surface> surfacePtr(
+      new mc_rbdyn::PlanarSurface(surfaceName, parentBodyName, sva::PTransformd::Identity(), "plastic", points));
+  robot.addSurface(surfacePtr);
+}
+
 static void BM_PolytopeJVRC1_3D_6DOF(benchmark::State & state)
 {
   // Setup part (not timed)
@@ -58,7 +67,9 @@ static void BM_PolytopeJVRC1_3D_6DOF(benchmark::State & state)
   }
 }
 // Register the function as a benchmark
-BENCHMARK(BM_PolytopeJVRC1_3D_6DOF)->Unit(benchmark::kMillisecond)->Repetitions(100)->DisplayAggregatesOnly(true);
+BENCHMARK(BM_PolytopeJVRC1_3D_6DOF)->Unit(benchmark::kMillisecond);
+// @todo consider setting number of repetitons to get standard deviation with
+// ->Repetitions(30)->DisplayAggregatesOnly(true);
 
 static void BM_PolytopeJVRC1_6D_6DOF(benchmark::State & state)
 {
@@ -110,4 +121,324 @@ static void BM_PolytopeJVRC1_6D_6DOF(benchmark::State & state)
   }
 }
 
-BENCHMARK(BM_PolytopeJVRC1_6D_6DOF)->Unit(benchmark::kMillisecond)->Repetitions(100)->DisplayAggregatesOnly(true);
+BENCHMARK(BM_PolytopeJVRC1_6D_6DOF)->Unit(benchmark::kMillisecond);
+
+static void BM_PolytopeJVRC1_3D_7DOF(benchmark::State & state)
+{
+  // Setup part (not timed)
+  auto robotModule = mc_rbdyn::RobotLoader::get_robot_module("JVRC1");
+  auto ground = mc_rbdyn::RobotLoader::get_robot_module("env/ground");
+  auto robots = mc_rbdyn::loadRobots({robotModule, ground});
+  auto & robot = robots->robot(robotModule->name);
+
+  mc_rtc::Configuration config;
+  config.add("withMoments", false);
+  config.add("HrepMode", false);
+  config.add("withFriction", true);
+
+  // Create simple contact
+  // JVRC1 arm: WAIST_Y -> WAIST_P -> WAIST_R -> R_SHOULDER_P -> R_SHOULDER_R -> R_SHOULDER_Y -> R_ELBOW_P
+  // ==> contact on R_ELBOW_P link is 7 dofs
+  addDummySurface(robot, "RForearm", "R_ELBOW_P_S");
+  mc_rbdyn::Contact RForearmContact(*robots, 0, 1, "RForearm", "AllGround");
+
+  // polytope dimension depending on moments option
+  config("withMoments") ? Rn::setDimension(6) : Rn::setDimension(3);
+
+  // Testing part
+  for(auto _ : state)
+  {
+    // Intentionally building job and input in the test loop to emulate lib runtime
+    mc_dynamic_polytopes::ContactPolytopeJob contactJob;
+    contactJob.contactRBDyn_ = &RForearmContact;
+    contactJob.ctl_ = NULL;
+    contactJob.HrepMode_ = config("HrepMode");
+    contactJob.combineWithFriction_ = config("withFriction");
+
+    // "job" inputs (simple defaults)
+    auto & input = contactJob.input();
+    input.contactName = "RForearm";
+    input.mb = robot.mb();
+    input.mbc = robot.mbc();
+    input.tl = robot.tl();
+    input.tu = robot.tu();
+    input.surface = robot.surface("RForearm").copy();
+    input.surfacePose = input.surface->X_0_s(robot);
+    input.accW = robot.accW();
+    input.refContactTransform = sva::PTransformd::Identity();
+    input.frictionCoefficient = 0.7;
+    input.forceScalingFactor = 1.0;
+
+    // run computation manually
+    contactJob.computeJob();
+  }
+}
+// Register the function as a benchmark
+BENCHMARK(BM_PolytopeJVRC1_3D_7DOF)->Unit(benchmark::kMillisecond);
+
+static void BM_PolytopeJVRC1_6D_7DOF(benchmark::State & state)
+{
+  // Setup part (not timed)
+  auto robotModule = mc_rbdyn::RobotLoader::get_robot_module("JVRC1");
+  auto ground = mc_rbdyn::RobotLoader::get_robot_module("env/ground");
+  auto robots = mc_rbdyn::loadRobots({robotModule, ground});
+  auto & robot = robots->robot(robotModule->name);
+
+  mc_rtc::Configuration config;
+  config.add("withMoments", true);
+  config.add("HrepMode", false);
+  config.add("withFriction", true);
+
+  // Create simple contact
+  // JVRC1 arm: WAIST_Y -> WAIST_P -> WAIST_R -> R_SHOULDER_P -> R_SHOULDER_R -> R_SHOULDER_Y -> R_ELBOW_P
+  // ==> contact on R_ELBOW_P link is 7 dofs
+  addDummySurface(robot, "RForearm", "R_ELBOW_P_S");
+  mc_rbdyn::Contact RForearmContact(*robots, 0, 1, "RForearm", "AllGround");
+
+  // polytope dimension depending on moments option
+  config("withMoments") ? Rn::setDimension(6) : Rn::setDimension(3);
+
+  // Testing part
+  for(auto _ : state)
+  {
+    // Intentionally building job and input in the test loop to emulate lib runtime
+    mc_dynamic_polytopes::ContactPolytopeJob contactJob;
+    contactJob.contactRBDyn_ = &RForearmContact;
+    contactJob.ctl_ = NULL;
+    contactJob.HrepMode_ = config("HrepMode");
+    contactJob.combineWithFriction_ = config("withFriction");
+
+    // "job" inputs (simple defaults)
+    auto & input = contactJob.input();
+    input.contactName = "RForearm";
+    input.mb = robot.mb();
+    input.mbc = robot.mbc();
+    input.tl = robot.tl();
+    input.tu = robot.tu();
+    input.surface = robot.surface("RForearm").copy();
+    input.surfacePose = input.surface->X_0_s(robot);
+    input.accW = robot.accW();
+    input.refContactTransform = sva::PTransformd::Identity();
+    input.frictionCoefficient = 0.7;
+    input.forceScalingFactor = 1.0;
+
+    // run computation manually
+    contactJob.computeJob();
+  }
+}
+// Register the function as a benchmark
+BENCHMARK(BM_PolytopeJVRC1_6D_7DOF)->Unit(benchmark::kMillisecond);
+
+static void BM_PolytopeJVRC1_3D_8DOF(benchmark::State & state)
+{
+  // Setup part (not timed)
+  auto robotModule = mc_rbdyn::RobotLoader::get_robot_module("JVRC1");
+  auto ground = mc_rbdyn::RobotLoader::get_robot_module("env/ground");
+  auto robots = mc_rbdyn::loadRobots({robotModule, ground});
+  auto & robot = robots->robot(robotModule->name);
+
+  mc_rtc::Configuration config;
+  config.add("withMoments", false);
+  config.add("HrepMode", false);
+  config.add("withFriction", true);
+
+  // Create simple contact
+  // JVRC1 arm: WAIST_Y -> WAIST_P -> WAIST_R -> R_SHOULDER_P -> R_SHOULDER_R -> R_SHOULDER_Y -> R_ELBOW_P -> R_ELBOW_Y
+  // ==> contact on R_ELBOW_Y link is 8 dofs
+  addDummySurface(robot, "RWrist", "R_ELBOW_Y_S");
+  mc_rbdyn::Contact RWristContact(*robots, 0, 1, "RWrist", "AllGround");
+
+  // polytope dimension depending on moments option
+  config("withMoments") ? Rn::setDimension(6) : Rn::setDimension(3);
+
+  // Testing part
+  for(auto _ : state)
+  {
+    // Intentionally building job and input in the test loop to emulate lib runtime
+    mc_dynamic_polytopes::ContactPolytopeJob contactJob;
+    contactJob.contactRBDyn_ = &RWristContact;
+    contactJob.ctl_ = NULL;
+    contactJob.HrepMode_ = config("HrepMode");
+    contactJob.combineWithFriction_ = config("withFriction");
+
+    // "job" inputs (simple defaults)
+    auto & input = contactJob.input();
+    input.contactName = "RWrist";
+    input.mb = robot.mb();
+    input.mbc = robot.mbc();
+    input.tl = robot.tl();
+    input.tu = robot.tu();
+    input.surface = robot.surface("RWrist").copy();
+    input.surfacePose = input.surface->X_0_s(robot);
+    input.accW = robot.accW();
+    input.refContactTransform = sva::PTransformd::Identity();
+    input.frictionCoefficient = 0.7;
+    input.forceScalingFactor = 1.0;
+
+    // run computation manually
+    contactJob.computeJob();
+  }
+}
+// Register the function as a benchmark
+BENCHMARK(BM_PolytopeJVRC1_3D_8DOF)->Unit(benchmark::kMillisecond);
+
+static void BM_PolytopeJVRC1_6D_8DOF(benchmark::State & state)
+{
+  // Setup part (not timed)
+  auto robotModule = mc_rbdyn::RobotLoader::get_robot_module("JVRC1");
+  auto ground = mc_rbdyn::RobotLoader::get_robot_module("env/ground");
+  auto robots = mc_rbdyn::loadRobots({robotModule, ground});
+  auto & robot = robots->robot(robotModule->name);
+
+  mc_rtc::Configuration config;
+  config.add("withMoments", true);
+  config.add("HrepMode", false);
+  config.add("withFriction", true);
+
+  // Create simple contact
+  // JVRC1 arm: WAIST_Y -> WAIST_P -> WAIST_R -> R_SHOULDER_P -> R_SHOULDER_R -> R_SHOULDER_Y -> R_ELBOW_P -> R_ELBOW_Y
+  // ==> contact on R_ELBOW_Y link is 8 dofs
+  addDummySurface(robot, "RWrist", "R_ELBOW_Y_S");
+  mc_rbdyn::Contact RWristContact(*robots, 0, 1, "RWrist", "AllGround");
+
+  // polytope dimension depending on moments option
+  config("withMoments") ? Rn::setDimension(6) : Rn::setDimension(3);
+
+  // Testing part
+  for(auto _ : state)
+  {
+    // Intentionally building job and input in the test loop to emulate lib runtime
+    mc_dynamic_polytopes::ContactPolytopeJob contactJob;
+    contactJob.contactRBDyn_ = &RWristContact;
+    contactJob.ctl_ = NULL;
+    contactJob.HrepMode_ = config("HrepMode");
+    contactJob.combineWithFriction_ = config("withFriction");
+
+    // "job" inputs (simple defaults)
+    auto & input = contactJob.input();
+    input.contactName = "RWrist";
+    input.mb = robot.mb();
+    input.mbc = robot.mbc();
+    input.tl = robot.tl();
+    input.tu = robot.tu();
+    input.surface = robot.surface("RWrist").copy();
+    input.surfacePose = input.surface->X_0_s(robot);
+    input.accW = robot.accW();
+    input.refContactTransform = sva::PTransformd::Identity();
+    input.frictionCoefficient = 0.7;
+    input.forceScalingFactor = 1.0;
+
+    // run computation manually
+    contactJob.computeJob();
+  }
+}
+// Register the function as a benchmark
+BENCHMARK(BM_PolytopeJVRC1_6D_8DOF)->Unit(benchmark::kMillisecond);
+
+static void BM_PolytopeJVRC1_3D_9DOF(benchmark::State & state)
+{
+  // Setup part (not timed)
+  auto robotModule = mc_rbdyn::RobotLoader::get_robot_module("JVRC1");
+  auto ground = mc_rbdyn::RobotLoader::get_robot_module("env/ground");
+  auto robots = mc_rbdyn::loadRobots({robotModule, ground});
+  auto & robot = robots->robot(robotModule->name);
+
+  mc_rtc::Configuration config;
+  config.add("withMoments", false);
+  config.add("HrepMode", false);
+  config.add("withFriction", true);
+
+  // Create simple contact
+  // JVRC1 arm: WAIST_Y -> WAIST_P -> WAIST_R -> R_SHOULDER_P -> R_SHOULDER_R -> R_SHOULDER_Y -> R_ELBOW_P -> R_ELBOW_Y
+  // -> R_WRIST_R
+  // ==> contact on R_WRIST_R_S link is 9 dofs
+  addDummySurface(robot, "RHand", "R_WRIST_R_S");
+  mc_rbdyn::Contact RHandContact(*robots, 0, 1, "RHand", "AllGround");
+
+  // polytope dimension depending on moments option
+  config("withMoments") ? Rn::setDimension(6) : Rn::setDimension(3);
+
+  // Testing part
+  for(auto _ : state)
+  {
+    // Intentionally building job and input in the test loop to emulate lib runtime
+    mc_dynamic_polytopes::ContactPolytopeJob contactJob;
+    contactJob.contactRBDyn_ = &RHandContact;
+    contactJob.ctl_ = NULL;
+    contactJob.HrepMode_ = config("HrepMode");
+    contactJob.combineWithFriction_ = config("withFriction");
+
+    // "job" inputs (simple defaults)
+    auto & input = contactJob.input();
+    input.contactName = "RHand";
+    input.mb = robot.mb();
+    input.mbc = robot.mbc();
+    input.tl = robot.tl();
+    input.tu = robot.tu();
+    input.surface = robot.surface("RHand").copy();
+    input.surfacePose = input.surface->X_0_s(robot);
+    input.accW = robot.accW();
+    input.refContactTransform = sva::PTransformd::Identity();
+    input.frictionCoefficient = 0.7;
+    input.forceScalingFactor = 1.0;
+
+    // run computation manually
+    contactJob.computeJob();
+  }
+}
+// Register the function as a benchmark
+BENCHMARK(BM_PolytopeJVRC1_3D_9DOF)->Unit(benchmark::kMillisecond);
+
+static void BM_PolytopeJVRC1_6D_9DOF(benchmark::State & state)
+{
+  // Setup part (not timed)
+  auto robotModule = mc_rbdyn::RobotLoader::get_robot_module("JVRC1");
+  auto ground = mc_rbdyn::RobotLoader::get_robot_module("env/ground");
+  auto robots = mc_rbdyn::loadRobots({robotModule, ground});
+  auto & robot = robots->robot(robotModule->name);
+
+  mc_rtc::Configuration config;
+  config.add("withMoments", true);
+  config.add("HrepMode", false);
+  config.add("withFriction", true);
+
+  // Create simple contact
+  // JVRC1 arm: WAIST_Y -> WAIST_P -> WAIST_R -> R_SHOULDER_P -> R_SHOULDER_R -> R_SHOULDER_Y -> R_ELBOW_P -> R_ELBOW_Y
+  // -> R_WRIST_R
+  // ==> contact on R_WRIST_R_S link is 9 dofs
+  addDummySurface(robot, "RHand", "R_WRIST_R_S");
+  mc_rbdyn::Contact RHandContact(*robots, 0, 1, "RHand", "AllGround");
+
+  // polytope dimension depending on moments option
+  config("withMoments") ? Rn::setDimension(6) : Rn::setDimension(3);
+
+  // Testing part
+  for(auto _ : state)
+  {
+    // Intentionally building job and input in the test loop to emulate lib runtime
+    mc_dynamic_polytopes::ContactPolytopeJob contactJob;
+    contactJob.contactRBDyn_ = &RHandContact;
+    contactJob.ctl_ = NULL;
+    contactJob.HrepMode_ = config("HrepMode");
+    contactJob.combineWithFriction_ = config("withFriction");
+
+    // "job" inputs (simple defaults)
+    auto & input = contactJob.input();
+    input.contactName = "RHand";
+    input.mb = robot.mb();
+    input.mbc = robot.mbc();
+    input.tl = robot.tl();
+    input.tu = robot.tu();
+    input.surface = robot.surface("RHand").copy();
+    input.surfacePose = input.surface->X_0_s(robot);
+    input.accW = robot.accW();
+    input.refContactTransform = sva::PTransformd::Identity();
+    input.frictionCoefficient = 0.7;
+    input.forceScalingFactor = 1.0;
+
+    // run computation manually
+    contactJob.computeJob();
+  }
+}
+// Register the function as a benchmark
+BENCHMARK(BM_PolytopeJVRC1_6D_9DOF)->Unit(benchmark::kMillisecond);

--- a/benchmark/bench.cpp
+++ b/benchmark/bench.cpp
@@ -1,7 +1,6 @@
 /* @todo
-- regarder instanciation faux robot comme dans tests unitaires mc_rtc
-- vérifier à quel point nb total de dofs impacte (taille calcul jacobienne inertie etc)
-- déterminer runtime loop quand le future() du thread de la lib est récupéré
+- Try out fake robots instanciations with chosen number of dofs like in mc_rtc unit tests
+- Check if total number of dofs in the robot has an impact (size of jacobian and inertia matrices)
 */
 
 #include <mc_rbdyn/RobotLoader.h>
@@ -9,7 +8,7 @@
 #include <benchmark/benchmark.h>
 #include <mc_dynamic_polytopes/DynamicPolytope.h>
 
-static void BM_PolytopeJVRC1(benchmark::State & state)
+static void BM_PolytopeJVRC1_3D_6DOF(benchmark::State & state)
 {
   // Setup part (not timed)
   auto robots = mc_rbdyn::loadRobot(*mc_rbdyn::RobotLoader::get_robot_module("JVRC1"));
@@ -20,29 +19,46 @@ static void BM_PolytopeJVRC1(benchmark::State & state)
   mc_rbdyn::RobotsPtr robotsList(mc_rbdyn::Robots::make());
   robotsList->robotCopy(robot, robot.name());
   robotsList->robotCopy(ground, ground.name());
-  // robotsList->load()
 
   mc_rtc::Configuration config;
   // Add required configuration keys if needed
   config.add("possibleContacts", std::vector<std::string>{"LeftFoot", "RightFoot"});
   config.add("withMoments", false);
-  config.add("computeRegions", true);
+  config.add("computeRegions", false);
   config.add("HrepMode", false);
   config.add("withFriction", true);
-  mc_dynamic_polytopes::DynamicPolytope polytopeComputer("test", robot, config);
 
-  // Set current active contacts (normally in controller run)
-  std::map<std::string, mc_rbdyn::Contact &> Contacts; // const_cast<mc_rbdyn::Robots &>(*robotsList)
+  // Create simple contact
   mc_rbdyn::Contact leftFootContact(const_cast<mc_rbdyn::Robots &>(*robotsList.get()), 0, 1, "LeftFoot", "AllGround");
-  Contacts.emplace(leftFootContact.r1Surface()->name(), leftFootContact);
+
+  // polytope dimension depending on moments option
+  config("withMoments") ? Rn::setDimension(6) : Rn::setDimension(3);
 
   // Testing part
   for(auto _ : state)
   {
-    polytopeComputer.setControllerContacts(Contacts);
-    polytopeComputer.computeRegions();
-    // @todo wait for polytope result
+    // Intentionally building job and input in the test loop to emulate lib runtime
+    mc_dynamic_polytopes::ContactPolytopeJob contactJob;
+    contactJob.contactRBDyn_ = &leftFootContact;
+    contactJob.ctl_ = NULL;
+
+    // "job" inputs (simple defaults)
+    auto & input = contactJob.input();
+    input.contactName = "LeftFoot";
+    input.mb = robot.mb();
+    input.mbc = robot.mbc();
+    input.tl = robot.tl();
+    input.tu = robot.tu();
+    input.surface = robot.surface("LeftFoot").copy();
+    input.surfacePose = input.surface->X_0_s(robot);
+    input.accW = robot.accW();
+    input.refContactTransform = sva::PTransformd::Identity();
+    input.frictionCoefficient = 0.7;
+    input.forceScalingFactor = 1.0;
+
+    // run computation manually
+    contactJob.computeJob();
   }
 }
 // Register the function as a benchmark
-BENCHMARK(BM_PolytopeJVRC1);
+BENCHMARK(BM_PolytopeJVRC1_3D_6DOF)->Unit(benchmark::kMillisecond);

--- a/benchmark/bench.cpp
+++ b/benchmark/bench.cpp
@@ -62,3 +62,58 @@ static void BM_PolytopeJVRC1_3D_6DOF(benchmark::State & state)
 }
 // Register the function as a benchmark
 BENCHMARK(BM_PolytopeJVRC1_3D_6DOF)->Unit(benchmark::kMillisecond);
+
+static void BM_PolytopeJVRC1_6D_6DOF(benchmark::State & state)
+{
+  // Setup part (not timed)
+  auto robots = mc_rbdyn::loadRobot(*mc_rbdyn::RobotLoader::get_robot_module("JVRC1"));
+  auto & robot = robots->robot();
+  auto envs = mc_rbdyn::loadRobot(*mc_rbdyn::RobotLoader::get_robot_module("env/ground"));
+  auto & ground = envs->robot();
+
+  mc_rbdyn::RobotsPtr robotsList(mc_rbdyn::Robots::make());
+  robotsList->robotCopy(robot, robot.name());
+  robotsList->robotCopy(ground, ground.name());
+
+  mc_rtc::Configuration config;
+  // Add required configuration keys if needed
+  config.add("possibleContacts", std::vector<std::string>{"LeftFoot", "RightFoot"});
+  config.add("withMoments", true);
+  config.add("computeRegions", false);
+  config.add("HrepMode", false);
+  config.add("withFriction", true);
+
+  // Create simple contact
+  mc_rbdyn::Contact leftFootContact(const_cast<mc_rbdyn::Robots &>(*robotsList.get()), 0, 1, "LeftFoot", "AllGround");
+
+  // polytope dimension depending on moments option
+  config("withMoments") ? Rn::setDimension(6) : Rn::setDimension(3);
+
+  // Testing part
+  for(auto _ : state)
+  {
+    // Intentionally building job and input in the test loop to emulate lib runtime
+    mc_dynamic_polytopes::ContactPolytopeJob contactJob;
+    contactJob.contactRBDyn_ = &leftFootContact;
+    contactJob.ctl_ = NULL;
+
+    // "job" inputs (simple defaults)
+    auto & input = contactJob.input();
+    input.contactName = "LeftFoot";
+    input.mb = robot.mb();
+    input.mbc = robot.mbc();
+    input.tl = robot.tl();
+    input.tu = robot.tu();
+    input.surface = robot.surface("LeftFoot").copy();
+    input.surfacePose = input.surface->X_0_s(robot);
+    input.accW = robot.accW();
+    input.refContactTransform = sva::PTransformd::Identity();
+    input.frictionCoefficient = 0.7;
+    input.forceScalingFactor = 1.0;
+
+    // run computation manually
+    contactJob.computeJob();
+  }
+}
+
+BENCHMARK(BM_PolytopeJVRC1_6D_6DOF)->Unit(benchmark::kMillisecond);

--- a/benchmark/bench.cpp
+++ b/benchmark/bench.cpp
@@ -1,0 +1,48 @@
+/* @todo
+- regarder instanciation faux robot comme dans tests unitaires mc_rtc
+- vérifier à quel point nb total de dofs impacte (taille calcul jacobienne inertie etc)
+- déterminer runtime loop quand le future() du thread de la lib est récupéré
+*/
+
+#include <mc_rbdyn/RobotLoader.h>
+#include <mc_rtc/Configuration.h>
+#include <benchmark/benchmark.h>
+#include <mc_dynamic_polytopes/DynamicPolytope.h>
+
+static void BM_PolytopeJVRC1(benchmark::State & state)
+{
+  // Setup part (not timed)
+  auto robots = mc_rbdyn::loadRobot(*mc_rbdyn::RobotLoader::get_robot_module("JVRC1"));
+  auto & robot = robots->robot();
+  auto envs = mc_rbdyn::loadRobot(*mc_rbdyn::RobotLoader::get_robot_module("env/ground"));
+  auto & ground = envs->robot();
+
+  mc_rbdyn::RobotsPtr robotsList(mc_rbdyn::Robots::make());
+  robotsList->robotCopy(robot, robot.name());
+  robotsList->robotCopy(ground, ground.name());
+  // robotsList->load()
+
+  mc_rtc::Configuration config;
+  // Add required configuration keys if needed
+  config.add("possibleContacts", std::vector<std::string>{"LeftFoot", "RightFoot"});
+  config.add("withMoments", false);
+  config.add("computeRegions", true);
+  config.add("HrepMode", false);
+  config.add("withFriction", true);
+  mc_dynamic_polytopes::DynamicPolytope polytopeComputer("test", robot, config);
+
+  // Set current active contacts (normally in controller run)
+  std::map<std::string, mc_rbdyn::Contact &> Contacts; // const_cast<mc_rbdyn::Robots &>(*robotsList)
+  mc_rbdyn::Contact leftFootContact(const_cast<mc_rbdyn::Robots &>(*robotsList.get()), 0, 1, "LeftFoot", "AllGround");
+  Contacts.emplace(leftFootContact.r1Surface()->name(), leftFootContact);
+
+  // Testing part
+  for(auto _ : state)
+  {
+    polytopeComputer.setControllerContacts(Contacts);
+    polytopeComputer.computeRegions();
+    // @todo wait for polytope result
+  }
+}
+// Register the function as a benchmark
+BENCHMARK(BM_PolytopeJVRC1);

--- a/benchmark/bench.cpp
+++ b/benchmark/bench.cpp
@@ -1,6 +1,6 @@
 /* @todo
-- Try out fake robots instanciations with chosen number of dofs like in mc_rtc unit tests
 - Check if total number of dofs in the robot has an impact (size of jacobian and inertia matrices)
+- Check if need to set random posture and dynamics to robot ? some calculations may be optimized if full zeros
 */
 
 #include <mc_rbdyn/RobotLoader.h>
@@ -11,25 +11,20 @@
 static void BM_PolytopeJVRC1_3D_6DOF(benchmark::State & state)
 {
   // Setup part (not timed)
-  auto robots = mc_rbdyn::loadRobot(*mc_rbdyn::RobotLoader::get_robot_module("JVRC1"));
-  auto & robot = robots->robot();
-  auto envs = mc_rbdyn::loadRobot(*mc_rbdyn::RobotLoader::get_robot_module("env/ground"));
-  auto & ground = envs->robot();
-
-  mc_rbdyn::RobotsPtr robotsList(mc_rbdyn::Robots::make());
-  robotsList->robotCopy(robot, robot.name());
-  robotsList->robotCopy(ground, ground.name());
+  auto robotModule = mc_rbdyn::RobotLoader::get_robot_module("JVRC1");
+  auto ground = mc_rbdyn::RobotLoader::get_robot_module("env/ground");
+  auto robots = mc_rbdyn::loadRobots({robotModule, ground});
+  auto & robot = robots->robot(robotModule->name);
 
   mc_rtc::Configuration config;
-  // Add required configuration keys if needed
-  config.add("possibleContacts", std::vector<std::string>{"LeftFoot", "RightFoot"});
   config.add("withMoments", false);
-  config.add("computeRegions", false);
   config.add("HrepMode", false);
   config.add("withFriction", true);
 
   // Create simple contact
-  mc_rbdyn::Contact leftFootContact(const_cast<mc_rbdyn::Robots &>(*robotsList.get()), 0, 1, "LeftFoot", "AllGround");
+  // JVRC1 leg: L_HIP_P -> L_HIP_R -> L_HIP_Y -> L_KNEE -> L_ANKLE_R -> L_ANKLE_P
+  // ==> 6 dofs
+  mc_rbdyn::Contact leftFootContact(*robots, 0, 1, "LeftFoot", "AllGround");
 
   // polytope dimension depending on moments option
   config("withMoments") ? Rn::setDimension(6) : Rn::setDimension(3);
@@ -41,6 +36,8 @@ static void BM_PolytopeJVRC1_3D_6DOF(benchmark::State & state)
     mc_dynamic_polytopes::ContactPolytopeJob contactJob;
     contactJob.contactRBDyn_ = &leftFootContact;
     contactJob.ctl_ = NULL;
+    contactJob.HrepMode_ = config("HrepMode");
+    contactJob.combineWithFriction_ = config("withFriction");
 
     // "job" inputs (simple defaults)
     auto & input = contactJob.input();
@@ -61,30 +58,25 @@ static void BM_PolytopeJVRC1_3D_6DOF(benchmark::State & state)
   }
 }
 // Register the function as a benchmark
-BENCHMARK(BM_PolytopeJVRC1_3D_6DOF)->Unit(benchmark::kMillisecond);
+BENCHMARK(BM_PolytopeJVRC1_3D_6DOF)->Unit(benchmark::kMillisecond)->Repetitions(100)->DisplayAggregatesOnly(true);
 
 static void BM_PolytopeJVRC1_6D_6DOF(benchmark::State & state)
 {
   // Setup part (not timed)
-  auto robots = mc_rbdyn::loadRobot(*mc_rbdyn::RobotLoader::get_robot_module("JVRC1"));
-  auto & robot = robots->robot();
-  auto envs = mc_rbdyn::loadRobot(*mc_rbdyn::RobotLoader::get_robot_module("env/ground"));
-  auto & ground = envs->robot();
-
-  mc_rbdyn::RobotsPtr robotsList(mc_rbdyn::Robots::make());
-  robotsList->robotCopy(robot, robot.name());
-  robotsList->robotCopy(ground, ground.name());
+  auto robotModule = mc_rbdyn::RobotLoader::get_robot_module("JVRC1");
+  auto ground = mc_rbdyn::RobotLoader::get_robot_module("env/ground");
+  auto robots = mc_rbdyn::loadRobots({robotModule, ground});
+  auto & robot = robots->robot(robotModule->name);
 
   mc_rtc::Configuration config;
-  // Add required configuration keys if needed
-  config.add("possibleContacts", std::vector<std::string>{"LeftFoot", "RightFoot"});
   config.add("withMoments", true);
-  config.add("computeRegions", false);
   config.add("HrepMode", false);
   config.add("withFriction", true);
 
   // Create simple contact
-  mc_rbdyn::Contact leftFootContact(const_cast<mc_rbdyn::Robots &>(*robotsList.get()), 0, 1, "LeftFoot", "AllGround");
+  // JVRC1 leg: L_HIP_P -> L_HIP_R -> L_HIP_Y -> L_KNEE -> L_ANKLE_R -> L_ANKLE_P
+  // ==> 6 dofs
+  mc_rbdyn::Contact leftFootContact(*robots, 0, 1, "LeftFoot", "AllGround");
 
   // polytope dimension depending on moments option
   config("withMoments") ? Rn::setDimension(6) : Rn::setDimension(3);
@@ -96,6 +88,8 @@ static void BM_PolytopeJVRC1_6D_6DOF(benchmark::State & state)
     mc_dynamic_polytopes::ContactPolytopeJob contactJob;
     contactJob.contactRBDyn_ = &leftFootContact;
     contactJob.ctl_ = NULL;
+    contactJob.HrepMode_ = config("HrepMode");
+    contactJob.combineWithFriction_ = config("withFriction");
 
     // "job" inputs (simple defaults)
     auto & input = contactJob.input();
@@ -116,4 +110,4 @@ static void BM_PolytopeJVRC1_6D_6DOF(benchmark::State & state)
   }
 }
 
-BENCHMARK(BM_PolytopeJVRC1_6D_6DOF)->Unit(benchmark::kMillisecond);
+BENCHMARK(BM_PolytopeJVRC1_6D_6DOF)->Unit(benchmark::kMillisecond)->Repetitions(100)->DisplayAggregatesOnly(true);


### PR DESCRIPTION
This tries to get a proper and reproducible measurement for the computation times of the library.
Only the individual contact polytopes are measured, not the bigger regions.

Some of the inputs are intentionally copied during the testing loop and will produce overhead similar to the actual usage of the library when arguments are passed to the threaded jobs.
Interested in your opinion on this @arntanguy as this is the first time I implement benchmarks.